### PR TITLE
Adding guard to avoid "already closed" exception from MapDB

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndexProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndexProvider.java
@@ -180,8 +180,10 @@ public class LocalIndexProvider extends IndexProvider {
         logger().debug("Shutting down the local index provider '{0}' in repository '{1}'", getName(), getRepositoryName());
         if (db != null) {
             try {
-                db.commit();
-                db.close();
+                if (!db.isClosed()) {
+                    db.commit();
+                    db.close();
+                }
             } finally {
                 db = null;
             }


### PR DESCRIPTION
If shutdown/undeploy of the repository and subsequently the index provider is called from a JVM shutdown hook, e.g. in the case of a spring managed scenario, then it is possible that the shutdown hook registered via MapDB will be call prior to the call to postShutdown.  In this scenario, MapDB will throw an IllegalStateException "already closed".  Adding simple guard to check for whether the MapDb instance is already closed.
